### PR TITLE
venv compatibility, add requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Requires Python 3.9 or higher.
 
 ### Libraries
 ```bash
-pip install google-api-python-client google-auth-httplib2 google-auth-oauthlib
+pip install -r requirements.txt
 ```
 
 ### Google API

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client
+google-auth-httplib2
+google-auth-oauthlib

--- a/youtube-upload.py
+++ b/youtube-upload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This script uploads a video to YouTube using the YouTube Data API v3.
 # It uses OAuth 2.0 for authentication, adapted for headless systems.


### PR DESCRIPTION
Some newer distributions prevent using the system-provided python with non-distribution-packaged python libraries. Instead they require use of a 'venv'. In this case we need to use the venv-provided python binary and not a hardcoded value. Every contemporary distribution provides `/usr/bin/env` as a way to find a binary in the current $PATH instead.

Also, `requirements.txt` is a more standard way of defining the required libs.