### PR TITLE
Restrict token file mode, stop logging secrets, pin Google libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # YouTube Upload Script
 
-Version 1.3.3
+Version 1.4.0
 
 ## Overview
 
@@ -18,7 +18,7 @@ A Python script for tech enthusiasts looking to automate video uploads to YouTub
 ## How It Works
 
 1. **Authentication**: Uses **OAuth 2.0** for secure access. The script provides a URL for manual entry on headless systems, with automatic token refresh to minimize re-authentication.
-    - **Token Management**: Automatically refreshes tokens when they expire, are invalid, or based on a configurable refresh interval. Tokens are stored in `youtube_oauth2_store.json`.
+    - **Token Management**: Automatically refreshes tokens when they expire, are invalid, or based on a configurable refresh interval. Tokens are stored in `youtube_oauth2_store.json` (file mode `600` after each save).
 
 2. **Upload Process**: 
     - Parses command-line arguments to define video metadata.
@@ -176,7 +176,7 @@ subject_prefix = [YouTube Upload]
 ## Setup
 ### Python
 
-Requires Python 3.9 or higher.
+Requires Python 3.10 or higher (pinned Google client libraries dropped 3.9).
 
 ### Libraries
 ```bash
@@ -189,7 +189,7 @@ pip install -r requirements.txt
     
 -   Create credentials for a Desktop app, download client_secrets.json, and place it at client_secrets_file location.
 
--  See detailed instruction in google-console-setup-instructions.md
+-   See detailed instructions in [google-console-setup-instructions.md](google-console-setup-instructions.md).
     
 
 ### Configuration
@@ -197,6 +197,12 @@ pip install -r requirements.txt
 -   Rename config.example.cfg to config.cfg and update paths and settings.
     
 -   Ensure the user running the script has read/write permissions for client_secrets_file, oauth2_storage_file, and log_file.
+
+-   Restrict secrets on disk: `chmod 600 config.cfg` (SMTP password and credential paths) and `chmod 600` on the OAuth token file (`oauth2_storage_file`). After each token write the script sets the token file mode to `0o600`.
+
+### OAuth out-of-band (OOB) flow
+
+Headless authentication still uses Google's paste-the-code OOB redirect (`urn:ietf:wg:oauth:2.0:oob`): the script prints an authorization URL, you sign in, then paste the code back. Google has **deprecated** this OOB flow; treating the pasted code as a secret is a known risk, and Google may reject OOB for some client types. This release does **not** change that flow.
 
 ### Email Notifications (Optional)
 
@@ -226,6 +232,15 @@ To enable email notifications for upload success/failure:
    ```bash
    python3 youtube-upload.py --videofile=video.mp4 --title="My Video" --email=override@example.com
    ```
+
+## Recent Changes (v1.4.0)
+
+### Security and hygiene
+- Token file (`oauth2_storage_file`) is set to mode `600` after each write.
+- Logs no longer include the raw authorization code or access/refresh token prefixes; only non-secret status (path, expiry, whether a refresh token is present).
+- Google client libraries are pinned in `requirements.txt` (`google-api-python-client>=2.199.0,<3` and matching pins). Python 3.10+ is required.
+- `config.cfg` and the token file should be `chmod 600`.
+- OOB paste-the-code authentication is documented as a Google-deprecated known risk; the OOB flow itself is unchanged.
 
 ## Recent Changes (v1.3.3)
 

--- a/google-console-setup-instructions.md
+++ b/google-console-setup-instructions.md
@@ -1,0 +1,57 @@
+# Google API Setup Instructions for YouTube Upload
+
+## Create a New Project in Google Cloud Console
+
+1. Go to the Google Cloud Console.
+2. Click the project dropdown at the top of the page (near the Google Cloud logo).
+3. Click **New Project** in the project selection dialog.
+4. Enter a Project name (e.g., *YouTubeUploadScript*).
+5. Optionally, select an Organization or leave it as "No organization."
+6. Click **Create**.
+7. Once created, select the new project from the project dropdown to ensure you're working in its context.
+
+## Enable the YouTube Data API v3
+
+1. In the Google Cloud Console, navigate to **APIs & Services** > **Library** in the left-hand menu.
+2. Search for "YouTube Data API v3".
+3. Click on **YouTube Data API v3** and then click **Enable**.
+    - If prompted, confirm the project selection.
+4. Wait for the API to be enabled (this may take a few seconds).
+
+## Configure the OAuth Consent Screen
+
+1. Go to **APIs & Services** > **OAuth consent screen** in the left-hand menu.
+2. Select the User Type:
+    - Choose **External** if the script will be used by users outside your organization (most common for personal projects).
+    - Choose **Internal** if the script is only for users within a Google Workspace organization.
+3. Click **Create**.
+4. Fill in the App information:
+    - **App name**: Enter a name (e.g., YouTube Uploader).
+    - **User support email**: Select or enter your email address.
+    - **Developer contact information**: Enter your email address.
+5. Under App domain, you can leave the fields blank unless you have specific URLs.
+6. Click **Save and Continue**.
+7. On the Scopes page:
+    - Click **Add or Remove Scopes**.
+    - Search for and select the following scopes:
+      - `https://www.googleapis.com/auth/youtube.upload`
+      - `https://www.googleapis.com/auth/youtube`
+    - Click **Update**, then **Save and Continue**.
+8. On the Test users page (if you selected External):
+    - Add your Google account email as a test user to allow testing without publishing.
+    - Click **Save and Continue**.
+9. Review the Summary page and click **Back to Dashboard**.
+
+## Create OAuth 2.0 Credentials
+
+1. Go to **APIs & Services** > **Credentials** in the left-hand menu.
+2. Click **Create Credentials** at the top and select **OAuth 2.0 Client IDs**.
+3. Configure the OAuth client:
+    - **Application type**: Select Desktop app.
+    - **Name**: Enter a name (e.g., YouTube Uploader Desktop Client).
+    - Leave other fields as default.
+4. Click **Create**.
+5. Download the credentials:
+    - In the OAuth 2.0 Client IDs section, find your new client ID.
+    - Click the Download button (download icon) to download the `client_secrets.json` file.
+6. Save the `client_secrets.json` file to the directory specified in your script's `config.cfg` file (e.g., the path set for `client_secrets_file`).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client
-google-auth-httplib2
-google-auth-oauthlib
+google-api-python-client>=2.199.0,<3
+google-auth-oauthlib>=1.4.1,<2
+google-auth-httplib2>=0.4.2,<1

--- a/youtube-upload.py
+++ b/youtube-upload.py
@@ -6,7 +6,7 @@
 # Automatically refreshes tokens to prevent manual re-authentication.
 # Exits with non-zero status code on critical upload errors (e.g., 400 uploadLimitExceeded).
 # Validates configuration file paths and exits with meaningful errors if invalid.
-# @version 1.3.3, 2025-09-26
+# @version 1.4.0, 2026-08-28
 
 import configparser
 import http.client
@@ -250,7 +250,8 @@ def save_tokens(credentials):
     try:
         with open(OAUTH2_STORAGE_FILE, "w") as f:  # Write tokens to file
             json.dump(tokens, f)
-            logger.info(f"Credentials saved to {OAUTH2_STORAGE_FILE}, expiry={credentials.expiry}")
+        os.chmod(OAUTH2_STORAGE_FILE, 0o600)  # Restrict token file to owner read/write
+        logger.info(f"Credentials saved to {OAUTH2_STORAGE_FILE}, expiry={credentials.expiry}")
     except OSError as e:
         logger.error(f"Failed to save OAuth tokens to '{OAUTH2_STORAGE_FILE}': {e}")
         sys.exit(1)  # Exit with non-zero status code
@@ -298,7 +299,7 @@ def get_authenticated_service(args):
                 token_uri=tokens["token_uri"],
                 scopes=tokens["scopes"]
             )
-            logger.info(f"Loaded credentials: token={creds.token[:10]}..., expiry={creds.expiry}, refresh_token={creds.refresh_token[:10] if creds.refresh_token else 'None'}...")
+            logger.info(f"Loaded credentials: expiry={creds.expiry}, has_refresh_token={bool(creds.refresh_token)}")
 
             # Check token expiry and refresh proactively
             current_time = datetime.now(timezone.utc)  # Get current UTC time
@@ -351,12 +352,12 @@ def get_authenticated_service(args):
         logger.info(f"Please visit this URL to authorize the application: {authorization_url}")
         print(f"Please visit this URL to authorize the application:\n{authorization_url}")
         code = input("Enter the authorization code: ").strip()  # Get auth code from user
-        logger.info(f"Authorization code entered: {code}")
+        logger.info("Authorization code received; exchanging for tokens.")
 
         try:
             flow.fetch_token(code=code)  # Exchange code for tokens
             creds = flow.credentials
-            logger.info(f"Credentials obtained: token={creds.token[:10]}..., expiry={creds.expiry}, refresh_token={creds.refresh_token[:10] if creds.refresh_token else 'None'}...")
+            logger.info(f"Credentials obtained: expiry={creds.expiry}, has_refresh_token={bool(creds.refresh_token)}")
             if not creds.expiry:  # Set default expiry if none provided
                 logger.warning("No expiry set after initial authentication, setting manually.")
                 creds.expiry = datetime.now(timezone.utc) + timedelta(seconds=3600)


### PR DESCRIPTION
## Summary
Behavior-preserving security and hygiene updates. OOB redirect, scopes, retry formula, SMTP, CLI defaults, upload payload, and token-refresh policy are unchanged.

- Set the OAuth token file to mode `600` after each JSON write (`save_tokens()`). JSON shape and path are unchanged.
- Stop logging the raw authorization code and access/refresh token prefixes; log non-secret status only (path, expiry, whether a refresh token is present).
- Pin Google client libraries to late-August 2026 stables, verified on PyPI:
  - `google-api-python-client>=2.199.0,<3` (2.199.0, Python >=3.10)
  - `google-auth-oauthlib>=1.4.1,<2` (1.4.1, Python >=3.10)
  - `google-auth-httplib2>=0.4.2,<1` (0.4.2, Python >=3.10)
- README: Python 3.10+, restore `google-console-setup-instructions.md`, document `chmod 600` for `config.cfg` and the token file, document OOB paste-the-code as a Google-deprecated known risk (flow not changed).
- Unify version string to **1.4.0** (script previously 1.3.3; historical commit titled “v 1.4”).

## Test plan
- [ ] Confirm existing `youtube_oauth2_store.json` still loads (same JSON keys/path).
- [ ] Run a token save (`--no-upload` or refresh) and check `stat`/`ls -l` shows mode `600` on the token file.
- [ ] Confirm logs contain no authorization code and no `token=` / `refresh_token=` prefixes.
- [ ] `pip install -r requirements.txt` on Python 3.10+.
- [ ] Confirm OOB URL still uses `urn:ietf:wg:oauth:2.0:oob` and paste-the-code still works as before.
- [ ] README link to `google-console-setup-instructions.md` resolves.